### PR TITLE
removed relatives call to Wire.h and SPI.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ In the .h file of your existing library add this lines just after the aruino.h i
 #include "yourlib.h"
 
 //here start the include
-#include <../SPI/SPI.h>//this chip needs SPI
+#include <SPI.h>//this chip needs SPI
 #include <../gpio_expander/mcp23s17.h>
 //here ends
 ```

--- a/gpio_expander.h
+++ b/gpio_expander.h
@@ -33,6 +33,10 @@
 #ifndef _GPIO_EXPANDER_H_
 #define _GPIO_EXPANDER_H_
 
+#ifndef NOT_AN_INTERRUPT
+#define NOT_AN_INTERRUPT -1
+#endif
+
 #include <inttypes.h>
 #include <Arduino.h>
 

--- a/max6957.cpp
+++ b/max6957.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "max6957.h"
-#include <../SPI/SPI.h>//this chip needs SPI
+#include <SPI.h>//this chip needs SPI
 
 max6957::max6957(){
 #if defined (SPI_HAS_TRANSACTION)

--- a/max6957.cpp
+++ b/max6957.cpp
@@ -8,7 +8,7 @@
 #include <../SPI/SPI.h>//this chip needs SPI
 
 max6957::max6957(){
-#if defined (SPI_HAS_TRANSACTION)
+#if defined (SPI_HAS_TRANSACTION) && (MAXSPISPEED)
 	_spiTransactionsSpeed = MAXSPISPEED;//set to max supported speed (in relation to chip and CPU)
 #else
 	_spiTransactionsSpeed = 0;
@@ -16,7 +16,7 @@ max6957::max6957(){
 }
 
 void max6957::setSPIspeed(uint32_t spispeed){
-	#if defined (SPI_HAS_TRANSACTION)
+	#if defined (SPI_HAS_TRANSACTION) && (MAXSPISPEED)
 	if (spispeed > 0){
 		if (spispeed > MAXSPISPEED) {
 			_spiTransactionsSpeed = MAXSPISPEED;

--- a/max6957.h
+++ b/max6957.h
@@ -195,7 +195,7 @@ XXXXX
 #include <inttypes.h>
 
 #include "gpio_expander.h"
-#include <../SPI/SPI.h>//this chip needs SPI
+#include <SPI.h>//this chip needs SPI
 
 #include "_utility/SPI.parameters.h"
 

--- a/max7301.cpp
+++ b/max7301.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "max7301.h"
-#include <../SPI/SPI.h>//this chip needs SPI
+#include <SPI.h>//this chip needs SPI
 
 max7301::max7301(){
 #if defined (SPI_HAS_TRANSACTION)

--- a/max7301.h
+++ b/max7301.h
@@ -195,7 +195,7 @@ XXXXX
 #include <inttypes.h>
 
 #include "gpio_expander.h"
-#include <../SPI/SPI.h>//this chip needs SPI
+#include <SPI.h>//this chip needs SPI
 
 #include "_utility/SPI.parameters.h"
 

--- a/max7311.cpp
+++ b/max7311.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "max7311.h"
-#include <../Wire/Wire.h>//this chip uses wire
+#include <Wire.h>//this chip uses wire
 
 max7311::max7311(){
 

--- a/max7318.cpp
+++ b/max7318.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "max7318.h"
-#include <../Wire/Wire.h>//this chip uses wire
+#include <Wire.h>//this chip uses wire
 
 max7318::max7318(){
 }

--- a/mcp23008.cpp
+++ b/mcp23008.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "mcp23008.h"
-#include <../Wire/Wire.h>//this chip uses wire
+#include <Wire.h>//this chip uses wire
 
 mcp23008::mcp23008(){
 

--- a/mcp23016.cpp
+++ b/mcp23016.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "mcp23016.h"
-#include <../Wire/Wire.h>//this chip uses wire
+#include <Wire.h>//this chip uses wire
 
 mcp23016::mcp23016(){
 

--- a/mcp23017.cpp
+++ b/mcp23017.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "mcp23017.h"
-#include <../Wire/Wire.h>//this chip uses wire
+#include <Wire.h>//this chip uses wire
 
 mcp23017::mcp23017(){
 	

--- a/mcp23018.cpp
+++ b/mcp23018.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "mcp23018.h"
-#include <../Wire/Wire.h>//this chip uses wire
+#include <Wire.h>//this chip uses wire
 
 mcp23018::mcp23018(){
 	

--- a/mcp23s08.cpp
+++ b/mcp23s08.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "mcp23s08.h"
-#include <../SPI/SPI.h>//this chip needs SPI
+#include <SPI.h>//this chip needs SPI
 
 mcp23s08::mcp23s08(){
 #if defined (SPI_HAS_TRANSACTION)

--- a/mcp23s08.h
+++ b/mcp23s08.h
@@ -67,7 +67,7 @@ A1,A0 tied to ground = 0x20
 #include <inttypes.h>
 
 #include "gpio_expander.h"
-#include <../SPI/SPI.h>//this chip needs SPI
+#include <SPI.h>//this chip needs SPI
 
 #include "_utility/SPI.parameters.h"
 

--- a/mcp23s17.cpp
+++ b/mcp23s17.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "mcp23s17.h"
-#include <../SPI/SPI.h>//this chip needs SPI
+#include <SPI.h>//this chip needs SPI
 
 mcp23s17::mcp23s17(){
 #if defined (SPI_HAS_TRANSACTION)

--- a/mcp23s17.h
+++ b/mcp23s17.h
@@ -73,7 +73,7 @@ A2,A1,A0 tied to ground = 0x20
 #include <inttypes.h>
 
 #include "gpio_expander.h"
-#include <../SPI/SPI.h>//this chip needs SPI
+#include <SPI.h>//this chip needs SPI
 
 #include "_utility/SPI.parameters.h"
 

--- a/mcp23s18.cpp
+++ b/mcp23s18.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "mcp23s18.h"
-#include <../SPI/SPI.h>//this chip needs SPI
+#include <SPI.h>//this chip needs SPI
 
 mcp23s18::mcp23s18(){
 #if defined (SPI_HAS_TRANSACTION)

--- a/mcp23s18.h
+++ b/mcp23s18.h
@@ -66,7 +66,7 @@ Address:  00100000 always 0x20
 #include <inttypes.h>
 
 #include "gpio_expander.h"
-#include <../SPI/SPI.h>//this chip needs SPI
+#include <SPI.h>//this chip needs SPI
 
 #include "_utility/SPI.parameters.h"
 

--- a/pca9555.cpp
+++ b/pca9555.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "pca9555.h"
-#include <../Wire/Wire.h>//this chip uses wire
+#include <Wire.h>//this chip uses wire
 
 pca9555::pca9555(){
 

--- a/pca9655.cpp
+++ b/pca9655.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "pca9655.h"
-#include <../Wire/Wire.h>//this chip uses wire
+#include <Wire.h>//this chip uses wire
 
 pca9655::pca9655(){
 

--- a/pcf8574.cpp
+++ b/pcf8574.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "pcf8574.h"
-#include <../Wire/Wire.h>//this chip uses wire
+#include <Wire.h>//this chip uses wire
 
 pcf8574::pcf8574(){
 

--- a/pcf8574a.cpp
+++ b/pcf8574a.cpp
@@ -5,7 +5,7 @@
 #include <Arduino.h>
 
 #include "pcf8574a.h"
-#include <../Wire/Wire.h>//this chip uses wire
+#include <Wire.h>//this chip uses wire
 
 pcf8574a::pcf8574a(){
 


### PR DESCRIPTION
As mentionned in #7 issue

../SPI/SPI.h
and
../Wire/Wire.h

are now repalced by

SPI.h
and
Wire.h

https://github.com/sumotoy/gpio_expander/issues/7